### PR TITLE
auth0 fixes

### DIFF
--- a/client/src/components/Auth0ProviderWithHistory.js
+++ b/client/src/components/Auth0ProviderWithHistory.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { useNavigate } from "react-router-dom";
+import { Auth0Provider } from '@auth0/auth0-react';
+
+const Auth0ProviderWithHistory = ({ children }) => {
+  const domain = "dev-smy0lct7oni31spt.us.auth0.com";
+  const clientId = "49LiusOQku1efCsU4Pw01K9XzQ8nxK4l";
+
+  const navigate = useNavigate();
+
+  const onRedirectCallback = (appState) => {
+    navigate(appState?.returnTo || window.location.pathname);
+  };
+
+  return (
+    <Auth0Provider
+      domain={domain}
+      clientId={clientId}
+      authorizationParams={{
+        redirect_uri: window.location.origin + "/admin/users",
+        audience: process.env.NODE_ENV === "development" ? "http://localhost:3000/api/" : "https://starter-kit-j5ar.onrender.com/api/"
+      }}
+      onRedirectCallback={onRedirectCallback}
+    >
+      {children}
+    </Auth0Provider>
+  );
+};
+
+export default Auth0ProviderWithHistory;

--- a/client/src/components/wrappers/WrapperAdmin.js
+++ b/client/src/components/wrappers/WrapperAdmin.js
@@ -24,7 +24,7 @@ export default function WrapperAdmin() {
             <Nav className="ms-auto">
               <Nav.Link as={Link} to="/admin/users" >Users</Nav.Link>
               <Nav.Link as={Link} to="/admin/ngos" >NGOs</Nav.Link>
-              {isAuthenticated && <Button variant="light" size="sm" onClick={() => logout({ returnTo: window.location.origin + "/admin" })}>Logout</Button>}
+              {isAuthenticated && <Button variant="light" size="sm" onClick={() => logout({ logoutParams: { returnTo: window.location.origin + "/admin" } })}>Logout</Button>}
             </Nav>
           </Navbar.Collapse>
         </Container>

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,20 +1,13 @@
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
-import { Auth0Provider } from "@auth0/auth0-react";
+import Auth0ProviderWithHistory from "./components/Auth0ProviderWithHistory";
 
 import App from "./App";
 
 createRoot(document.getElementById("root")).render(
-	<Auth0Provider
-		domain="dev-smy0lct7oni31spt.us.auth0.com"
-		clientId="49LiusOQku1efCsU4Pw01K9XzQ8nxK4l"
-    authorizationParams={{
-			redirect_uri: window.location.origin + "/admin/users",
-			audience: process.env.NODE_ENV === "development" ? "http://localhost:3000/api/" : "https://starter-kit-j5ar.onrender.com/api/"
-    }}
-  >
-		<BrowserRouter>
+	<BrowserRouter>
+		<Auth0ProviderWithHistory>
 			<App />
-		</BrowserRouter>
-  </Auth0Provider>
+		</Auth0ProviderWithHistory>
+	</BrowserRouter>
 );


### PR DESCRIPTION
Fixes:
- on Render the application was always taking the user to the users page when refreshing the NGO page.
- on both Render and localhost, when trying to access the NGO page without being logged in, then taken to login page, then after successful login, the user would always be redirected to the users page, with the NGO page URL showing in the browser. Now the user is taken to the NGO page.
- when logging out, only the first allowed logout URL was being selected. logging out takes you to the correct place on both Render and localhost